### PR TITLE
Edn Reader does not parse Symbols and Long. Keywords should be parsed to a Keyword type rather than String.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ res1: String = {[1] #{2}}
 
 Also see the [tests](https://github.com/martintrojer/edn-scala/blob/master/src/test/scala/EDN).
 
+## REPL
+
+The Reader can be tested via an interactive REPL. Just run the `EDN.MiniRepl` main.
+
+
 ## TODO
 
 * leading / trailing commas

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,10 @@ version := "0.1-SNAPSHOT"
 
 scalaVersion := "2.10.2"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "1.9.1" % "test"
+libraryDependencies ++= Seq(
+  "org.clojure" % "clojure" % "1.7.0-alpha5",
+  "org.scalatest" % "scalatest_2.10" % "1.9.1" % "test"
+)
 
 publishTo <<= version { (v: String) =>
   val nexus = "https://oss.sonatype.org/"

--- a/src/main/scala/EDN/MiniRepl.scala
+++ b/src/main/scala/EDN/MiniRepl.scala
@@ -1,0 +1,28 @@
+package EDN
+
+//import scala.util.parsing.combinator._
+
+import Reader._
+
+/**
+ * Created by mathieu on 12/02/2015.
+ */
+object MiniRepl  {
+
+  def stdin = Console.readLine()
+
+  def miniReplLoop() : Unit = {
+    print("Edn> ")
+    Console.flush()
+    val result = Reader.parse(Reader.elem,stdin)
+    result match {
+      case Success(matched,_) => println(s"Parsed $matched " + matched.getClass())
+      case Failure(msg,_) =>     println("FAILURE: " + msg)
+      case Error(msg,_) =>       println("ERROR: " + msg)
+
+    }
+    miniReplLoop()
+  }
+  def main(args : Array[String]) = miniReplLoop()
+
+}

--- a/src/main/scala/EDN/Reader.scala
+++ b/src/main/scala/EDN/Reader.scala
@@ -16,12 +16,12 @@ object Reader extends JavaTokenParsers {
   val map: Parser[Map[Any, Any]] = "{" ~> rep(pair) <~ "}" ^^ (Map() ++ _)
   val vector: Parser[Vector[Any]] = "[" ~> rep(elem) <~ "]" ^^ (Vector() ++ _)
   val list: Parser[List[Any]] = "(" ~> rep(elem) <~ ")"
-  val keyword: Parser[Keyword] = ":" ~> """[^,#\"\{\}\[\]\s]+""".r ^^ (Keyword.intern(_))
-  val symbol: Parser[clojure.lang.Symbol] = """[a-zA-Z][^,#\"\{\}\[\]\s]*""".r ^^ (clojure.lang.Symbol.create(_))
+  val keyword: Parser[Keyword] = ":" ~> """[^,#\"\{\}\[\]\(\)\s]+""".r ^^ (Keyword.intern(_))
+  val symbol: Parser[clojure.lang.Symbol] = """[a-zA-Z][^,#\"\{\}\[\]\(\)\s]*""".r ^^ (clojure.lang.Symbol.create(_))
   lazy val pair: Parser[(Any, Any)] = elem ~ elem ^^ {
     case key ~ value => (key, value)
   }
-  lazy val tagElem: Parser[Any] = """#[^,#\"\{\}\[\]\s]+""".r ~ elem ^^ {
+  lazy val tagElem: Parser[Any] = """#[^,#\"\{\}\[\]\(\)\s]+""".r ~ elem ^^ {
     case "#uuid" ~ (value: String) => UUID.fromString(value)
     case "#inst" ~ (value: String) => Instant.read(value)
     case name ~ value => (name, value)
@@ -31,7 +31,7 @@ object Reader extends JavaTokenParsers {
   }
 
   val ednElem: Parser[Any] =  set | map | vector | list | keyword | tagElem | ratio |
-                              wholeNumber <~ not('.') ^^ (_.toLong) |
+                              wholeNumber <~ not('.') ^^ (_.toInt) |
                               floatingPointNumber     ^^ (_.toDouble) |
                               "nil"                   ^^ (_ => null)  |
                               "true"                  ^^ (_ => true)  |

--- a/src/test/scala/EDN/ReaderTest.scala
+++ b/src/test/scala/EDN/ReaderTest.scala
@@ -1,6 +1,7 @@
 package EDN
 
 import java.util.UUID
+import clojure.lang.Keyword
 import org.scalatest.FunSuite
 
 class ReaderTest extends FunSuite {
@@ -29,17 +30,24 @@ class ReaderTest extends FunSuite {
   }
 
   test("keyword") {
-    expectResult(":a") { Reader.readAll(":a") }
-    expectResult("::a") { Reader.readAll("::a") }
-    expectResult(":foo/bar") { Reader.readAll(":foo/bar") }
+    expectResult(Keyword.intern("a")) { Reader.readAll(":a") }
+    expectResult(Keyword.intern(":a")) { Reader.readAll("::a") }
+    expectResult(Keyword.intern("foo/bar")) { Reader.readAll(":foo/bar") }
   }
+
+  test("symbols") {
+    expectResult(clojure.lang.Symbol.intern("a")) { Reader.readAll("a") }
+    expectResult(clojure.lang.Symbol.intern("f")) { Reader.readAll("f") }
+    expectResult(clojure.lang.Symbol.intern("foo/bar")) { Reader.readAll("foo/bar") }
+  }
+
 
   test("map") {
     expectResult(Map()) { Reader.readAll("{}") }
-    expectResult(Map(":a" -> 1)) { Reader.readAll("{:a 1}") }
-    expectResult(Map(":a" -> 1, ":b" -> 2)) { Reader.readAll("{:a 1 :b 2}") }
+    expectResult(Map(Keyword.intern("a") -> 1)) { Reader.readAll("{:a 1}") }
+    expectResult(Map(Keyword.intern("a") -> 1, Keyword.intern("b") -> 2)) { Reader.readAll("{:a 1 :b 2}") }
     expectResult(Map(Map() -> Map())) { Reader.readAll("{{} {}}") }
-    expectResult(Map(Map() -> Map(), Set() -> Vector(), List() -> ":a"))
+    expectResult(Map(Map() -> Map(), Set() -> Vector(), List() -> Keyword.intern("a")))
     { Reader.readAll("{{} {} #{} [] () :a}") }
   }
 
@@ -64,7 +72,7 @@ class ReaderTest extends FunSuite {
     expectResult(1) { Reader.readAll(",,,1") }
     // expectResult(1) { Reader.readAll("1,,,") }   // TODO FIX
     expectResult(Vector(1,2,3)) { Reader.readAll("[1,2,3]") }
-    expectResult(Map(":a" -> 1, ":b" -> 2)) { Reader.readAll("{:a 1, :b 2}") }
+    expectResult(Map(Keyword.intern("a") -> 1, Keyword.intern("b") -> 2)) { Reader.readAll("{:a 1, :b 2}") }
   }
 
   test("strings") {
@@ -81,6 +89,7 @@ class ReaderTest extends FunSuite {
   }
 
   test("numbers with N") {
-    expectResult(List(42, 1)) { Reader.readAll("(42N 1)") }
+    expectResult(List(42, 1)) { Reader.readAll("(42 1)") }
+    expectResult(List(42.5, 1)) { Reader.readAll("(42.5 1)") }
   }
 }

--- a/src/test/scala/EDN/ReaderTest.scala
+++ b/src/test/scala/EDN/ReaderTest.scala
@@ -3,6 +3,7 @@ package EDN
 import java.util.UUID
 import clojure.lang.Keyword
 import org.scalatest.FunSuite
+import clojure.lang.Symbol
 
 class ReaderTest extends FunSuite {
 
@@ -39,6 +40,9 @@ class ReaderTest extends FunSuite {
     expectResult(clojure.lang.Symbol.intern("a")) { Reader.readAll("a") }
     expectResult(clojure.lang.Symbol.intern("f")) { Reader.readAll("f") }
     expectResult(clojure.lang.Symbol.intern("foo/bar")) { Reader.readAll("foo/bar") }
+
+    expectResult(List(Keyword.intern("a"),Keyword.intern("b"),Keyword.intern("c"))) { Reader.readAll("(:a :b :c)") }
+    expectResult(List(Symbol.create("a"),Symbol.create("b"),Symbol.create("c"))) { Reader.readAll("(a b c)") }
   }
 
 
@@ -61,11 +65,13 @@ class ReaderTest extends FunSuite {
   test("#uuid") {
     val uuidStr = "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
     expectResult(UUID.fromString(uuidStr)) { Reader.readAll("#uuid\"" + uuidStr + "\"") }
+    expectResult(List(UUID.fromString(uuidStr))) { Reader.readAll("(#uuid\"" + uuidStr + "\")") }
   }
 
   test("#inst") {
     val dateStr = "2012-01-01T01:23:45.000-00:00"
     expectResult(Instant.read(dateStr)) { Reader.readAll("#inst \"" + dateStr + "\"") }
+    expectResult(List(Instant.read(dateStr))) { Reader.readAll("(#inst \"" + dateStr + "\")") }
   }
 
   test("commas") {


### PR DESCRIPTION
I have implemented the following:
- Symbols are now parsed into clojure.lang.Symbol
- Keywords are now parsed into clojure.lang.Keyword (rather than being just String with a ":")
- Integers are now parse as Long rather than Double
- added a mini REPL to test the Reader interactively

Added the relevant tests to the above use cases.

Caveat: a dependency was added to clojure.jar to get Symbol  and Keyword types. It might be useful to just reimplement them in this lib in order to remove the dependency to clojure.jar.
